### PR TITLE
Add languages support to GitFlame API & Refactor

### DIFF
--- a/qa/utils/git_services/gitflame_api.py
+++ b/qa/utils/git_services/gitflame_api.py
@@ -2,20 +2,21 @@ import os
 import asyncio
 import threading
 import typing
+import httpx
 import requests
 
 from qa.utils.summarize import summarize
 
 
 class GitFlameAPI():
-    def __init__(self, model:str = "openai"):
+    def __init__(self, model: str = "openai"):
         self.api_url = "https://gitflame.ru/api/v1/repos"
         self.model = model
 
     async def search_repositories(self, query: str, results: list, n_repos: int, lang: str = "ru") -> list:
         try:
             repositories = requests.get(
-                url=self.search_url(),
+                url=self.get_search_url(),
                 params={
                     "page": 1,
                     "limit": n_repos,
@@ -26,14 +27,12 @@ class GitFlameAPI():
             search_results = []
             threads = []
 
-            for repo_data_dict in repositories.json():
-                print(repo_data_dict)
-                scraped_info = await self.scrape_info(repo_data_dict=repo_data_dict)
+            for repo_data in repositories.json():
 
                 _t = threading.Thread(
                     target=asyncio.run,
                     args=(self.process_result(
-                        scraped_info, search_results, lang),),
+                        repo_data, search_results, lang),),
                     daemon=True,
                 )
                 threads.append(_t)
@@ -47,7 +46,7 @@ class GitFlameAPI():
             print(f"An error occurred: {e}")
             return []
 
-    def search_url(self) -> str:
+    def get_search_url(self) -> str:
         return self.api_url + "/search"
 
     def get_readme_urls(self, owner: str, repo_name: str) -> typing.List[str]:
@@ -63,44 +62,61 @@ class GitFlameAPI():
             url=readme_url)
         if readme.status_code == 200 and not readme.content.decode().startswith("<!DOCTYPE html>"):
             return readme.content.decode()
-        print(f"Can not find readme.md for gitflame for this link: {readme_url}")
+        print(f"Can not find readme.md for gitflame for this link: {
+              readme_url}")
         return ""
 
-    async def scrape_info(self, repo_data_dict: dict) -> dict:
+    async def get_languages(self, languages_url: str):
+      async with httpx.AsyncClient(timeout=10) as client:
+          response = await client.get(languages_url)
+      if response.status_code == 200:
+          languages_data = response.json()
+          total_bytes = sum(languages_data.values())
+          return {lang: f"{(bytes / total_bytes) * 100:.2f}%" for lang, bytes in languages_data.items()}
+      else:
+          return "Languages for this repo were not found or access denied."
 
-        info = {}
+    # This function is never called, as gitflame requires authentaction
+    # to access the collaborators api endpoint, and I couldn't find a way to
+    # do the authentication as gitflame doesn't support api keys
+    async def get_contributors(self, repo_fullname: str):
+      contributors_url = f"{self.api_url}/{repo_fullname}/collaborators"
 
-        info["repo_url"] = repo_data_dict["html_url"]
+      async with httpx.AsyncClient(timeout=10) as client:
+          response = await client.get(contributors_url)
+          print(response)
+          return [contributor["login"] for contributor in response.json()] if response.status_code == 200 else "Contributors not found or access denied."
 
-        info["repo_name"] = repo_data_dict["name"]
+    async def process_result(self, data: dict, results: list, lang: str = "en") -> None:
+        # A repo's fullname is the name of the owner followed by a '/', then by repo's name
+        repo_fullname = data["full_name"]
 
-        info["repo_owner"] = repo_data_dict["owner"]["username"]
+        repo_name = data["name"]
+        repo_url = data["html_url"]
+        repo_owner = data["owner"]["username"]
+        repo_forks = data["forks_count"]
+        repo_stars = data["stars_count"]
+        repo_languages = await self.get_languages(data["languages_url"])
+        # repo_contributors = await self.get_contributors(repo_fullname)
+        repo_contributors = "N/A"
 
-        for possible_readme_url in self.get_readme_urls(owner=info["repo_owner"], repo_name=info["repo_name"]):
-            repo_readme_content = await self.get_readme_content(possible_readme_url)
-            if repo_readme_content != "":
-                info["readme_content"] = repo_readme_content
-                break
+        # GitFlame doesn't support adding a license to a repository, that's
+        # why we're defaulting to "N/A" here.
+        repo_license = "N/A"
 
-        info["description"] = repo_data_dict["description"]
-        info["stars_count"] = repo_data_dict["stars_count"]
-        info["forks_count"] = repo_data_dict["forks_count"]
-        info['licence'] = repo_data_dict['licence']
+        repo_description = data.get(
+            "descriptoin", "There is no description for this repo")
 
-        return info
+        for possible_readme_url in self.get_readme_urls(owner=repo_owner, repo_name=repo_name):
+          repo_readme_content = await self.get_readme_content(possible_readme_url)
+          if repo_readme_content != "":
+            data["readme_content"] = repo_readme_content
+            break
 
-    async def process_result(self, info: dict, results: list, lang: str = "en") -> None:
-        repo_name = info["repo_name"]
-        repo_url = info["repo_url"]
-        repo_owner = info["repo_owner"]
-        repo_forks = info["forks_count"]
-        repo_stars = info["stars_count"]
-        repo_licence = info['licence']
-        repo_description = info["description"] if info["description"] != "" else "There is no description for this repo"
-        repo_readme_content = info.get(
+        repo_readme_content = data.get(
             "readme_content", "There is no README for this repo")
 
-        summary = await summarize(lang, repo_readme_content, repo_description,self.model)
+        summary = await summarize(lang, repo_readme_content, repo_description, self.model)
 
         results.append(
             {
@@ -110,12 +126,15 @@ class GitFlameAPI():
                 "url": repo_url,
                 "forks": repo_forks,
                 "stars": repo_stars,
-                "licence": repo_licence,
+                "license": repo_license,
+                "languages": repo_languages,
+                "contributors": repo_contributors,
                 "description": repo_description,
                 "readme_content": repo_readme_content,
                 "summary": summary,
             }
         )
+
 
     async def get_repo_info(self, repo_url: str, lang: str) -> dict:
         repo_name = repo_url.split("/")[4]
@@ -138,7 +157,7 @@ class GitFlameAPI():
             "forks": 0,
             "stars": 0,
             "summary": summary,
-            "licence": "",
+            "license": "N/A",
         }
 
         return info


### PR DESCRIPTION
As far as I've seen, GitFlame doesn't support licenses. Moreover, to get the contributors of a project, you need to be authenticated. And as far as I've seen, GitFlame doesn't support any sort of automatic authentication methods such as access keys. That's why only languages support was added.